### PR TITLE
Show approximate address and NGO name in events list

### DIFF
--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -26,6 +26,15 @@ document.addEventListener "turbolinks:load", ->
     $('#event_lng').val coords[0]
     $('#event_lat').val coords[1]
 
+    props = suggestion.properties
+    approximate_address = (
+      if props && props["Bezirk"] && props["Municipality"]
+        "#{props["Bezirk"]}. Bezirk, #{props["Municipality"]}"
+      else
+        ""
+    )
+    $('#event_approximate_address').val approximate_address
+
   addressSearch = new Bloodhound
     datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value')
     queryTokenizer: Bloodhound.tokenizers.whitespace

--- a/app/controllers/ngos/events_controller.rb
+++ b/app/controllers/ngos/events_controller.rb
@@ -71,7 +71,7 @@ class Ngos::EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :person, :title, :description, :address, :lat, :lng,
+      :person, :title, :description, :address, :lat, :lng, :approximate_address,
       shifts_attributes: [:id, :volunteers_needed, :starts_at, :ends_at, :_destroy]
     )
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ApplicationRecord
   scope :with_available_shifts, -> {
     published.
     where(id: Shift.available.pluck(:event_id).uniq).
-    includes(:available_shifts).
+    includes(:available_shifts, :ngo).
     order("shifts.starts_at").
     references(:available_shifts)
   }

--- a/app/views/admin/events/_show.builder
+++ b/app/views/admin/events/_show.builder
@@ -8,6 +8,7 @@ context.instance_eval do
       row :address
       row(:coordinates) { |event| "(#{event.lat}, #{event.lng})" }
       row(:description) { |event| format_description(event.description) }
+      row :approximate_address
       row(:state){ |ngo| status_tag(Event.human_attribute_name("state-#{ngo.state}")) }
       row :created_at
       row :updated_at

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -16,8 +16,9 @@
       <%= ", " + further_events_count.to_s + " weitere "  if further_events_count > 0 %></br>
 
       <strong><%= event.title %></strong><br>
-      <span><%= event.person %></span>
-      <span><%= event.address %></span>
+      <span><%= event.approximate_address.present? ? event.approximate_address : event.address %></span>
+      <span>–</span>
+      <span><%= event.ngo.name %></span>
     </div>
     <div class="col-xs-3 col-sm-2">
       <%= render event.progress_bar(current_user) %>

--- a/app/views/ngos/events/_form.html.erb
+++ b/app/views/ngos/events/_form.html.erb
@@ -17,6 +17,7 @@
   <%= f.input :person, placeholder: true %>
   <%= f.input :lat, as: :hidden %>
   <%= f.input :lng, as: :hidden %>
+  <%= f.input :approximate_address, as: :hidden %>
 
   <hr/>
   <h3><%= t 'ngos.events.form.shifts' %></h3>

--- a/config/locales/active_record.de.yml
+++ b/config/locales/active_record.de.yml
@@ -39,6 +39,7 @@ de:
         title: Titel
         description: Beschreibung
         address: Adresse
+        approximate_address: Ungefähre Adresse
         state: Status
         state/pending: Unsichtbar
         state/published: Sichtbar

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -38,6 +38,7 @@ en:
         title: Title
         description: Description
         address: Address
+        approximate_address: Approximate Address
         state: Status
         state/pending: Invisible
         state/published: Visible

--- a/db/migrate/20161110173401_add_approximate_address_to_event.rb
+++ b/db/migrate/20161110173401_add_approximate_address_to_event.rb
@@ -1,0 +1,5 @@
+class AddApproximateAddressToEvent < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :approximate_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012175641) do
+ActiveRecord::Schema.define(version: 20161110173401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,13 +57,14 @@ ActiveRecord::Schema.define(version: 20161012175641) do
     t.string   "address"
     t.float    "lat"
     t.float    "lng"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.integer  "ngo_id"
     t.string   "title"
     t.datetime "deleted_at"
     t.datetime "published_at"
     t.string   "person"
+    t.string   "approximate_address"
     t.index ["deleted_at"], name: "index_events_on_deleted_at", using: :btree
     t.index ["ngo_id"], name: "index_events_on_ngo_id", where: "(deleted_at IS NULL)", using: :btree
     t.index ["published_at"], name: "index_events_on_published_at", where: "(deleted_at IS NULL)", using: :btree

--- a/lib/tasks/db/populate.rake
+++ b/lib/tasks/db/populate.rake
@@ -97,7 +97,8 @@ namespace :db do
         zip = feature["properties"]["PostalCode"]
         zip ||= "10#{feature["properties"]["Bezirk"].split(',').first.rjust(2, '0')}"
         address = "#{zip}, #{event.address}"
-        event.update(lng: coords[0], lat: coords[1], address: address)
+        approximate_address = "#{feature["properties"]["Bezirk"]}. Bezirk, #{feature["properties"]["Municipality"]}"
+        event.update(lng: coords[0], lat: coords[1], address: address, approximate_address: approximate_address)
       end
     end
   end


### PR DESCRIPTION
In the event list, showing the full address and contact details is not necessary (and takes up space / blurs focus). The list should allow volunteers to quickly scan for events based on **when** and **where** they are, but the latter doesn't have to be a full fletched address. Also, **who** organizes the event might be a criterion as well.

This PR adds an `approximate_address` field to events. That field is not visible in the event form, but it is automatically filled with `"<xx>. Bezirk, <City>"` when NGOs select an address in the address autocomplete. In the event list, this approximate address (if present) replaces the full address display. Also, instead of showing the contact person details, the NGO name is displayed.

When testing this, make sure to `rake db:populate` again, to have some test data. In production, I will manually enter the approximate addresses for existing events when we deploy this.
